### PR TITLE
Fixed crash on ICMP request on unprivileged nodes

### DIFF
--- a/rei/checkers/icmp.py
+++ b/rei/checkers/icmp.py
@@ -24,7 +24,7 @@ class ICMPChecker(BaseChecker):
     async def check(self) -> Response:
 
         try:
-            host = await async_ping(self.target)
+            host = await async_ping(self.target, privileged=False)
         except NameLookupError:
             return self.create_not_alive_response()
 


### PR DESCRIPTION
In short, `icmplib` by default assumes, that current process is running
as root, and makes low-level socket by itself. But there is a way to
tell kernel itself do its job and make proper ICMP request *without*
root privileges. That fixes an issue.

Recently I realized that my node is behaving not as intended, but after
short investigation, I figured out, that it fails on `/check/icmp` request
with `icmplib.exceptions.SocketPermissionError`.
